### PR TITLE
Add conditional events feature to Generic Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,40 @@ Controller - button.
 ### Generic Button parameters:
 - Header - header to be displayed on a button
 - Skin - select button skin, either Boeing-like or Airbus-like
-- Button event - event to be triggered by button press
+- Event Mode - select between Simple or Conditional event mode
+  - **Simple mode**: Single event triggered by button press
+  - **Conditional mode**: Different events triggered based on variable value
+- Button event (Simple mode) - event to be triggered by button press
+- Conditional Variable (Conditional mode) - Variable to evaluate for condition
+- Operator (Conditional mode) - Comparison operator (==, !=, >, <, >=, <=)
+- Condition Value (Conditional mode) - Value to compare against
+- Event When True (Conditional mode) - Event to send when condition is true
+- Event When False (Conditional mode) - Event to send when condition is false
 - Display variable - Variable used in displaying additional data on a button if necessary
 - Status variable - Variable used in displaying active status (green light in the button bottom)
 
+#### Conditional Events
+Now Generic Button supports conditional events. This allows button to send different events based on SimConnect variable value.
+For example, you could configure Autopilot button to send AP_MASTER event to turn AP on when it's off, and same AP_MASTER event to turn it off when it's on.
+Or configure Landing Gear button to send GEAR_UP when gear is extended and GEAR_DOWN when gear is retracted, based on GEAR TOTAL PCT EXTENDED variable value.
+
+Conditional mode supports 6 comparison operators:
+- == (Equal) - condition is true when variable equals specified value
+- != (Not Equal) - condition is true when variable differs from specified value
+- > (Greater Than) - condition is true when variable is greater than specified value
+- < (Less Than) - condition is true when variable is less than specified value
+- >= (Greater or Equal) - condition is true when variable is greater than or equal to specified value
+- <= (Less or Equal) - condition is true when variable is less than or equal to specified value
+
+Example configuration for smart Autopilot toggle:
+- Event Mode: Conditional
+- Conditional Variable: AUTOPILOT MASTER
+- Operator: == (Equal)
+- Condition Value: 1
+- Event When True: AP_MASTER (to turn off when AP is on)
+- Event When False: AP_MASTER (to turn on when AP is off)
+- Status variable: AUTOPILOT MASTER (to show green light when AP is active)
+ 
 ## Generic Dial (single)
 This action intended to implement plane dial on Stream Dock display. Dial can display value, change value by rotating a knob, call event by pressing a knob/screen.
 Controller - Knob/Display.

--- a/com.rvoronov.msfsDock.sdPlugin/GenericButton/index.html
+++ b/com.rvoronov.msfsDock.sdPlugin/GenericButton/index.html
@@ -10,6 +10,18 @@
     .sdpi-item {
       margin: 2px auto;
     }
+
+    #conditionalSection {
+      background-color: rgba(255, 255, 255, 0.05);
+      padding: 10px;
+      border-radius: 5px;
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
+
+    #conditionalSection .sdpi-item {
+      margin-bottom: 8px;
+    }
   </style>
 </head>
 
@@ -26,10 +38,61 @@
         <option value="skin2">Airbus</option>
       </select>
     </div>
+
+    <!-- Conditional Events Toggle -->
     <div class="sdpi-item">
-        <div class="sdpi-item-label" title="Sim event to be called when button pressed">Button event</div>
-        <input class="sdpi-item-value" id="toggleEvent" list="toggleEventList" value="" placeholder="EVENT" pattern="[A-Za-z0-9:_. ]*">
-        <datalist id="toggleEventList"></datalist>
+      <div class="sdpi-item-label" title="Enable conditional events based on variable value">Event Mode</div>
+      <select class="sdpi-item-value" id="useConditionalEvents">
+        <option value="false">Simple</option>
+        <option value="true">Conditional</option>
+      </select>
+    </div>
+
+    <!-- Legacy Mode (shown when conditional is disabled) -->
+    <div id="legacySection">
+      <div class="sdpi-item">
+          <div class="sdpi-item-label" title="Sim event to be called when button pressed">Button event</div>
+          <input class="sdpi-item-value" id="toggleEvent" list="toggleEventList" value="" placeholder="EVENT" pattern="[A-Za-z0-9:_. ]*">
+          <datalist id="toggleEventList"></datalist>
+      </div>
+    </div>
+
+    <!-- Conditional Mode (hidden by default) -->
+    <div id="conditionalSection" style="display: none;">
+      <div class="sdpi-item">
+        <div class="sdpi-item-label" title="Variable to evaluate for condition">Conditional Variable</div>
+        <input class="sdpi-item-value" id="conditionalVar" list="conditionalVarList" value="" placeholder="CONDITIONAL VARIABLE" pattern="[A-Za-z0-9:_. ]*">
+        <datalist id="conditionalVarList"></datalist>
+      </div>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label" title="Comparison operator">Operator</div>
+        <select class="sdpi-item-value" id="conditionOperator">
+          <option value="==">== (Equal)</option>
+          <option value="!=">!= (Not Equal)</option>
+          <option value=">">> (Greater Than)</option>
+          <option value="<">< (Less Than)</option>
+          <option value=">=">>= (Greater or Equal)</option>
+          <option value="<="><= (Less or Equal)</option>
+        </select>
+      </div>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label" title="Value to compare against">Condition Value</div>
+        <input class="sdpi-item-value" type="number" id="conditionValue" value="0" placeholder="0" step="any">
+      </div>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label" title="Event to send when condition is true">Event When True</div>
+        <input class="sdpi-item-value" id="eventWhenTrue" list="eventWhenTrueList" value="" placeholder="EVENT WHEN TRUE" pattern="[A-Za-z0-9:_. ]*">
+        <datalist id="eventWhenTrueList"></datalist>
+      </div>
+
+      <div class="sdpi-item">
+        <div class="sdpi-item-label" title="Event to send when condition is false">Event When False</div>
+        <input class="sdpi-item-value" id="eventWhenFalse" list="eventWhenFalseList" value="" placeholder="EVENT WHEN FALSE" pattern="[A-Za-z0-9:_. ]*">
+        <datalist id="eventWhenFalseList"></datalist>
+      </div>
     </div>
 
     <div class="sdpi-item">

--- a/com.rvoronov.msfsDock.sdPlugin/GenericButton/index.js
+++ b/com.rvoronov.msfsDock.sdPlugin/GenericButton/index.js
@@ -3,9 +3,17 @@ const $local = false, $back = false,
         main: $('.sdpi-wrapper'),
         header: $("#header"),
         skin: $("#skin"),
+        useConditionalEvents: $("#useConditionalEvents"),
         toggleEvent: $("#toggleEvent"),
+        conditionalVar: $("#conditionalVar"),
+        conditionOperator: $("#conditionOperator"),
+        conditionValue: $("#conditionValue"),
+        eventWhenTrue: $("#eventWhenTrue"),
+        eventWhenFalse: $("#eventWhenFalse"),
         feedbackVar: $("#feedbackVar"),
         displayVar: $("#displayVar"),
+        legacySection: $("#legacySection"),
+        conditionalSection: $("#conditionalSection"),
     },
     $propEvent = {
         didReceiveSettings() {
@@ -16,8 +24,26 @@ const $local = false, $back = false,
             if ($settings.skin) {
                 $dom.skin.value = $settings.skin;
             }
+            if ($settings.useConditionalEvents !== undefined) {
+                $dom.useConditionalEvents.value = String($settings.useConditionalEvents);
+            }
             if ($settings.toggleEvent) {
                 $dom.toggleEvent.value = $settings.toggleEvent;
+            }
+            if ($settings.conditionalVar) {
+                $dom.conditionalVar.value = $settings.conditionalVar;
+            }
+            if ($settings.conditionOperator) {
+                $dom.conditionOperator.value = $settings.conditionOperator;
+            }
+            if ($settings.conditionValue !== undefined) {
+                $dom.conditionValue.value = $settings.conditionValue;
+            }
+            if ($settings.eventWhenTrue) {
+                $dom.eventWhenTrue.value = $settings.eventWhenTrue;
+            }
+            if ($settings.eventWhenFalse) {
+                $dom.eventWhenFalse.value = $settings.eventWhenFalse;
             }
             if ($settings.feedbackVar) {
                 $dom.feedbackVar.value = $settings.feedbackVar;
@@ -25,6 +51,7 @@ const $local = false, $back = false,
             if ($settings.displayVar) {
                 $dom.displayVar.value = $settings.displayVar;
             }
+            updateConditionalMode();
         },
         sendToPropertyInspector(data) { }
     };
@@ -32,16 +59,41 @@ const $local = false, $back = false,
 // --- Initialize lastSentValue for all fields ---
 $dom.header.lastSentValue = $dom.header.value;
 $dom.skin.lastSentValue = $dom.skin.value;
+$dom.useConditionalEvents.lastSentValue = $dom.useConditionalEvents.value;
 $dom.toggleEvent.lastSentValue = $dom.toggleEvent.value;
+$dom.conditionalVar.lastSentValue = $dom.conditionalVar.value;
+$dom.conditionOperator.lastSentValue = $dom.conditionOperator.value;
+$dom.conditionValue.lastSentValue = $dom.conditionValue.value;
+$dom.eventWhenTrue.lastSentValue = $dom.eventWhenTrue.value;
+$dom.eventWhenFalse.lastSentValue = $dom.eventWhenFalse.value;
 $dom.feedbackVar.lastSentValue = $dom.feedbackVar.value;
 $dom.displayVar.lastSentValue = $dom.displayVar.value;
+
+// Update visibility based on conditional mode
+function updateConditionalMode() {
+    const useConditional = ($dom.useConditionalEvents.value === 'true');
+    
+    if (useConditional) {
+        $dom.conditionalSection.style.display = 'block';
+        $dom.legacySection.style.display = 'none';
+    } else {
+        $dom.conditionalSection.style.display = 'none';
+        $dom.legacySection.style.display = 'block';
+    }
+}
 
 // Helper to send both values together with real-change check
 function updateSettings() {
     const data = {
         header: $dom.header.value,
         skin: $dom.skin.value,
+        useConditionalEvents: ($dom.useConditionalEvents.value === 'true'),
         toggleEvent: $dom.toggleEvent.value,
+        conditionalVar: $dom.conditionalVar.value,
+        conditionOperator: $dom.conditionOperator.value,
+        conditionValue: parseFloat($dom.conditionValue.value) || 0,
+        eventWhenTrue: $dom.eventWhenTrue.value,
+        eventWhenFalse: $dom.eventWhenFalse.value,
         feedbackVar: $dom.feedbackVar.value,
         displayVar: $dom.displayVar.value,
     };
@@ -50,7 +102,13 @@ function updateSettings() {
     if (
         data.header === $dom.header.lastSentValue &&
         data.skin === $dom.skin.lastSentValue &&
+        String(data.useConditionalEvents) === $dom.useConditionalEvents.lastSentValue &&
         data.toggleEvent === $dom.toggleEvent.lastSentValue &&
+        data.conditionalVar === $dom.conditionalVar.lastSentValue &&
+        data.conditionOperator === $dom.conditionOperator.lastSentValue &&
+        data.conditionValue === $dom.conditionValue.lastSentValue &&
+        data.eventWhenTrue === $dom.eventWhenTrue.lastSentValue &&
+        data.eventWhenFalse === $dom.eventWhenFalse.lastSentValue &&
         data.feedbackVar === $dom.feedbackVar.lastSentValue &&
         data.displayVar === $dom.displayVar.lastSentValue
     ) {
@@ -60,7 +118,13 @@ function updateSettings() {
     // --- Save current values as last sent ---
     $dom.header.lastSentValue = data.header;
     $dom.skin.lastSentValue = data.skin;
+    $dom.useConditionalEvents.lastSentValue = String(data.useConditionalEvents);
     $dom.toggleEvent.lastSentValue = data.toggleEvent;
+    $dom.conditionalVar.lastSentValue = data.conditionalVar;
+    $dom.conditionOperator.lastSentValue = data.conditionOperator;
+    $dom.conditionValue.lastSentValue = data.conditionValue;
+    $dom.eventWhenTrue.lastSentValue = data.eventWhenTrue;
+    $dom.eventWhenFalse.lastSentValue = data.eventWhenFalse;
     $dom.feedbackVar.lastSentValue = data.feedbackVar;
     $dom.displayVar.lastSentValue = data.displayVar;
 
@@ -70,7 +134,16 @@ function updateSettings() {
 // Listen to input events and send full payload
 $dom.header.on("input", updateSettings);
 $dom.skin.on("change", updateSettings);
+$dom.useConditionalEvents.on("change", () => {
+    updateConditionalMode();
+    updateSettings();
+});
 $dom.toggleEvent.on("change", updateSettings);
+$dom.conditionalVar.on("change", updateSettings);
+$dom.conditionOperator.on("change", updateSettings);
+$dom.conditionValue.on("input", updateSettings);
+$dom.eventWhenTrue.on("change", updateSettings);
+$dom.eventWhenFalse.on("change", updateSettings);
 $dom.feedbackVar.on("change", updateSettings);
 $dom.displayVar.on("change", updateSettings);
 
@@ -87,6 +160,24 @@ $propEvent.sendToPropertyInspector = (data) => {
 
         new SDPIAutocomplete(
             $dom.toggleEvent,
+            () => commonEvents,
+            updateSettings
+        );
+
+        new SDPIAutocomplete(
+            $dom.conditionalVar,
+            () => commonVars,
+            updateSettings
+        );
+
+        new SDPIAutocomplete(
+            $dom.eventWhenTrue,
+            () => commonEvents,
+            updateSettings
+        );
+
+        new SDPIAutocomplete(
+            $dom.eventWhenFalse,
             () => commonEvents,
             updateSettings
         );

--- a/core/ButtonAction.cpp
+++ b/core/ButtonAction.cpp
@@ -13,7 +13,6 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
 
     // Conditional events configuration
     useConditionalEvents_ = settings.value("useConditionalEvents", false);
-    conditionalVar_ = settings.value("conditionalVar", "");
     conditionOperator_ = settings.value("conditionOperator", "==");
     conditionValue_ = settings.value("conditionValue", 0.0);
     eventWhenTrue_ = settings.value("eventWhenTrue", "");
@@ -26,6 +25,7 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
 
     std::string newDisplay = settings.value("displayVar", "");
     std::string newFeedback = settings.value("feedbackVar", "");
+    std::string newConditional = settings.value("conditionalVar", "");
     std::string newEvent = settings.value("toggleEvent", "");
 
     // Remove variables if necessary
@@ -43,7 +43,7 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
         varsToDeregister.push_back({ feedbackVar_, FEEDBACK_VARIABLE });
     }
 
-    if (!conditionalVar_.empty() && !settings.contains("conditionalVar")) {
+    if (!conditionalVar_.empty() && conditionalVar_ != newConditional) {
         if (conditionalSubId_) {
             SimManager::Instance().UnsubscribeFromVariable(conditionalVar_, conditionalSubId_);
         }
@@ -79,8 +79,7 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
     }
 
     // Register conditional variable if needed
-    std::string newConditional = settings.value("conditionalVar", "");
-    if (useConditionalEvents_ && !newConditional.empty()) {
+    if (useConditionalEvents_ && !newConditional.empty() && newConditional != conditionalVar_) {
         conditionalVarDef_.name = newConditional;
         conditionalVarDef_.group = FEEDBACK_VARIABLE;
         varsToRegister.push_back(conditionalVarDef_);
@@ -117,6 +116,7 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
     // Save new values
     displayVar_ = newDisplay;
     feedbackVar_ = newFeedback;
+    conditionalVar_ = newConditional;
     toggleEvent_ = newEvent;
 
     // Subscribe callbacks

--- a/core/ButtonAction.cpp
+++ b/core/ButtonAction.cpp
@@ -2,7 +2,7 @@
 #include "plugin/Logger.hpp"
 #include "ui/GDIPlusManager.hpp"
 #include "SimData/SimData.hpp"
-
+#include <cmath>
 
 void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
     if (!payload.contains("settings")) return;
@@ -10,6 +10,14 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
 
     header_ = settings.value("header", "");
     skin_ = settings.value("skin", "skin1");
+
+    // Conditional events configuration
+    useConditionalEvents_ = settings.value("useConditionalEvents", false);
+    conditionalVar_ = settings.value("conditionalVar", "");
+    conditionOperator_ = settings.value("conditionOperator", "==");
+    conditionValue_ = settings.value("conditionValue", 0.0);
+    eventWhenTrue_ = settings.value("eventWhenTrue", "");
+    eventWhenFalse_ = settings.value("eventWhenFalse", "");
 
     std::vector<SimVarDefinition> varsToRegister;
     std::vector<SimVarDefinition> varsToDeregister;
@@ -35,8 +43,26 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
         varsToDeregister.push_back({ feedbackVar_, FEEDBACK_VARIABLE });
     }
 
+    if (!conditionalVar_.empty() && !settings.contains("conditionalVar")) {
+        if (conditionalSubId_) {
+            SimManager::Instance().UnsubscribeFromVariable(conditionalVar_, conditionalSubId_);
+        }
+        varsToDeregister.push_back({ conditionalVar_, FEEDBACK_VARIABLE });
+    }
+
+    // Deregister old events
     if (!toggleEvent_.empty() && toggleEvent_ != newEvent) {
         eventsToDeregister.push_back({toggleEvent_});
+    }
+
+    std::string oldEventWhenTrue = eventWhenTrue_;
+    std::string oldEventWhenFalse = eventWhenFalse_;
+    
+    if (!oldEventWhenTrue.empty() && oldEventWhenTrue != eventWhenTrue_) {
+        eventsToDeregister.push_back({oldEventWhenTrue});
+    }
+    if (!oldEventWhenFalse.empty() && oldEventWhenFalse != eventWhenFalse_) {
+        eventsToDeregister.push_back({oldEventWhenFalse});
     }
 
     // Add new variables if necessary
@@ -52,9 +78,29 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
         varsToRegister.push_back(feedbackVarDef_);
     }
 
-    if (!newEvent.empty() && newEvent != toggleEvent_) {
-        toggleEventDef_.name = newEvent;
-        eventsToRegister.push_back(toggleEventDef_);
+    // Register conditional variable if needed
+    std::string newConditional = settings.value("conditionalVar", "");
+    if (useConditionalEvents_ && !newConditional.empty()) {
+        conditionalVarDef_.name = newConditional;
+        conditionalVarDef_.group = FEEDBACK_VARIABLE;
+        varsToRegister.push_back(conditionalVarDef_);
+    }
+
+    // Register events based on mode
+    if (useConditionalEvents_) {
+        if (!eventWhenTrue_.empty()) {
+            eventWhenTrueDef_.name = eventWhenTrue_;
+            eventsToRegister.push_back(eventWhenTrueDef_);
+        }
+        if (!eventWhenFalse_.empty()) {
+            eventWhenFalseDef_.name = eventWhenFalse_;
+            eventsToRegister.push_back(eventWhenFalseDef_);
+        }
+    } else {
+        if (!newEvent.empty() && newEvent != toggleEvent_) {
+            toggleEventDef_.name = newEvent;
+            eventsToRegister.push_back(toggleEventDef_);
+        }
     }
 
     // Call add/remove
@@ -74,14 +120,20 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
     toggleEvent_ = newEvent;
 
     // Subscribe callbacks
-    if (!newDisplay.empty()) {
-        displaySubId_ = SimManager::Instance().SubscribeToVariable(newDisplay,
+    if (!displayVar_.empty()) {
+        displaySubId_ = SimManager::Instance().SubscribeToVariable(displayVar_,
             [this](const std::string& name, double value) {
                 this->OnVariableUpdated(name, value);
             });
     }
-    if (!newFeedback.empty()) {
-        feedbackSubId_ = SimManager::Instance().SubscribeToVariable(newFeedback,
+    if (!feedbackVar_.empty()) {
+        feedbackSubId_ = SimManager::Instance().SubscribeToVariable(feedbackVar_,
+            [this](const std::string& name, double value) {
+                this->OnVariableUpdated(name, value);
+            });
+    }
+    if (useConditionalEvents_ && !conditionalVar_.empty()) {
+        conditionalSubId_ = SimManager::Instance().SubscribeToVariable(conditionalVar_,
             [this](const std::string& name, double value) {
                 this->OnVariableUpdated(name, value);
             });
@@ -91,8 +143,12 @@ void ButtonAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
 void ButtonAction::OnVariableUpdated(const std::string& name, double value) {
     if (name == displayVar_) {
         displayVarDef_.value = value;
-    } else if (name == feedbackVar_) {
-        isActive = (value == 0) ? false : true;
+    }
+    if (name == feedbackVar_) {
+        isActive = (value != 0.0);
+    }
+    if (name == conditionalVar_) {
+        conditionalVarDef_.value = value;
     }
     UpdateImage();
 }
@@ -110,8 +166,12 @@ void ButtonAction::KeyDown(const nlohmann::json& payload) {
         return;
     }
 
-    if (!toggleEvent_.empty()) {
-        SimManager::Instance().SendEvent(toggleEvent_);
+    std::string eventToSend = GetEventToSend();
+    if (!eventToSend.empty()) {
+        LogInfo("Sending event: " + eventToSend);
+        SimManager::Instance().SendEvent(eventToSend);
+    } else {
+        LogInfo("No event to send (empty event name)");
     }
 }
 
@@ -119,11 +179,44 @@ void ButtonAction::KeyUp(const nlohmann::json& /*payload*/) {
     // not used for now
 }
 
+std::string ButtonAction::GetEventToSend() const {
+    if (!useConditionalEvents_) {
+        return toggleEvent_;
+    }
+
+    double varValue = conditionalVarDef_.value;
+    bool conditionMet = false;
+
+    if (conditionOperator_ == "==") {
+        conditionMet = (std::abs(varValue - conditionValue_) < 0.0001);
+    } else if (conditionOperator_ == "!=") {
+        conditionMet = (std::abs(varValue - conditionValue_) >= 0.0001);
+    } else if (conditionOperator_ == ">") {
+        conditionMet = (varValue > conditionValue_);
+    } else if (conditionOperator_ == "<") {
+        conditionMet = (varValue < conditionValue_);
+    } else if (conditionOperator_ == ">=") {
+        conditionMet = (varValue >= conditionValue_);
+    } else if (conditionOperator_ == "<=") {
+        conditionMet = (varValue <= conditionValue_);
+    }
+
+    std::string result = conditionMet ? eventWhenTrue_ : eventWhenFalse_;
+    LogInfo("Condition evaluation: varValue=" + std::to_string(varValue) + 
+            " conditionValue=" + std::to_string(conditionValue_) + 
+            " operator=" + conditionOperator_ + 
+            " result=" + (conditionMet ? "TRUE" : "FALSE") + 
+            " event=" + result);
+    
+    return result;
+}
+
 void ButtonAction::SendToPI(const nlohmann::json& payload) {
     nlohmann::json out_payload;
     out_payload["type"] = "evt_var_list";
     out_payload["common_events"] = nlohmann::json::array();
     out_payload["common_variables"] = nlohmann::json::array();
+    out_payload["operators"] = nlohmann::json::array({"==", "!=", ">", "<", ">=", "<="});
 
     for (const auto& evt : GetKnownVariables()) {
         out_payload["common_variables"].push_back(evt);
@@ -148,24 +241,43 @@ void ButtonAction::WillDisappear(const nlohmann::json& /*payload*/) {
     LogInfo("ButtonAction WillDisappear");
     std::vector<SimVarDefinition> vars;
     std::vector<SimEventDefinition> events;
+    
     if (!displayVar_.empty()) {
         if (displaySubId_) {
             SimManager::Instance().UnsubscribeFromVariable(displayVar_, displaySubId_);
         }
         vars.push_back({displayVar_, LIVE_VARIABLE});
     }
+    
     if (!feedbackVar_.empty()) {
         if (feedbackSubId_) {
             SimManager::Instance().UnsubscribeFromVariable(feedbackVar_, feedbackSubId_);
         }
         vars.push_back({feedbackVar_, FEEDBACK_VARIABLE});
     }
+    
+    if (!conditionalVar_.empty()) {
+        if (conditionalSubId_) {
+            SimManager::Instance().UnsubscribeFromVariable(conditionalVar_, conditionalSubId_);
+        }
+        vars.push_back({conditionalVar_, FEEDBACK_VARIABLE});
+    }
+    
     if (!vars.empty()) {
         SimManager::Instance().RemoveSimVars(vars);
     }
 
     if (!toggleEvent_.empty()) {
         events.push_back({toggleEvent_});
+    }
+    if (!eventWhenTrue_.empty()) {
+        events.push_back({eventWhenTrue_});
+    }
+    if (!eventWhenFalse_.empty()) {
+        events.push_back({eventWhenFalse_});
+    }
+    
+    if (!events.empty()) {
         SimManager::Instance().RemoveSimEvents(events);
     }
 
@@ -178,9 +290,16 @@ void ButtonAction::ClearSettings() {
     displayVar_.clear();
     feedbackVar_.clear();
     toggleEvent_.clear();
+    conditionalVar_.clear();
+    eventWhenTrue_.clear();
+    eventWhenFalse_.clear();
 
     displaySubId_ = 0;
     feedbackSubId_ = 0;
+    conditionalSubId_ = 0;
+    useConditionalEvents_ = false;
+    conditionValue_ = 0.0;
+    conditionOperator_ = "==";
 }
 
 void ButtonAction::UpdateImage() {

--- a/core/ButtonAction.hpp
+++ b/core/ButtonAction.hpp
@@ -28,6 +28,7 @@ public:
 private:
     void UpdateVariablesAndEvents(const nlohmann::json& payload);
     void ClearSettings();
+    std::string GetEventToSend() const;
 
     // parsed settings
     std::string displayVar_;
@@ -37,6 +38,14 @@ private:
     bool isActive = false;
     std::string skin_;
 
+    // Conditional events support
+    bool useConditionalEvents_ = false;
+    std::string conditionalVar_;
+    std::string conditionOperator_;
+    double conditionValue_ = 0.0;
+    std::string eventWhenTrue_;
+    std::string eventWhenFalse_;
+
     const std::wstring b_Inactive = L"images/button.png";
     const std::wstring b_Active = L"images/button_active.png";
     const std::wstring ab_Inactive = L"images/button_ab.png";
@@ -44,8 +53,12 @@ private:
 
     SimVarDefinition displayVarDef_;
     SimVarDefinition feedbackVarDef_;
+    SimVarDefinition conditionalVarDef_;
     SimEventDefinition toggleEventDef_;
+    SimEventDefinition eventWhenTrueDef_;
+    SimEventDefinition eventWhenFalseDef_;
 
     SubscriptionId displaySubId_ = 0;
     SubscriptionId feedbackSubId_ = 0;
+    SubscriptionId conditionalSubId_ = 0;
 };


### PR DESCRIPTION
This merge adds support for conditional behavior in generic button configurations. The new functionality allows selecting a simulator variable, applying an operator and a condition, and sending one event when the condition evaluates to true and another when it evaluates to false.