### PR TITLE
Fix critical SimConnect variable data desynchronization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ compile_commands.json
 #macOS
 .DS_Store
 
+# Dev Notes Folder
+priv_folder/
+
 # Visual Studio Code
 build/
 .vscode

--- a/core/DialAction.cpp
+++ b/core/DialAction.cpp
@@ -327,6 +327,7 @@ void DialAction::ClearSettings() {
     toggleEvent_.clear();
 
     displaySubId_ = 0;
+    display2SubId_ = 0;
     feedbackSubId_ = 0;
 }
 


### PR DESCRIPTION
- Add order tracking vectors (liveVarOrder_, feedbackVarOrder_) to maintain exact SimConnect registration order
- Rewrite ParseGroupValues to iterate using registration order instead of alphabetical map order
- Always advance buffer pointer even for unused variables to prevent value shift
- Fix missing display2SubId_ cleanup in DialAction::ClearSettings
- Extend IsValueValid range to ±1e12 for GPS coordinates and large altitude values
- Add proper order vector cleanup in DeregisterVariablesFromSim and NotifyAndClearAllVariables

This tries to fix the bug where variables would display incorrect values depending on configuration.