### PR TITLE
feat:Add Vertical Gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ Controller - button.
 - Positions - Define mapping of switch position value in sim (left field) and displayed text (right field, 5 characters max).
 
 ## Generic Gauge
-This action intended to display data from Sim on Stream Dock button with gauge like interface.
+This action intended to display data from Sim on Stream Dock button with gauge like interface. Gauge supports two skins - circular (classic round gauge) and vertical (bar gauge).
 Controller - Button.
 ### Generic Gauge parameters:
 - Header - header to be displayed on a gauge
 - Display variable - Variable used in displaying data
+- Skin - select gauge skin, Circular (round gauge) or Vertical (bar gauge)
 - Format - Format of displayed data, integer or percent value.
 - Style - Select gauge style, Indicator - display current value with indicator on a scale, Fill - fill scale up to current value
 - Min value - Minimum value of a gauge
@@ -135,6 +136,14 @@ Controller - Button.
 - Scale - choose scale color (default - Yellow)
 - Indicator - choose indicator color (default - Red)
 - Background - choose background color (default - Black)
+
+#### Vertical gauge specific
+When Vertical skin is selected additional options become available:
+- Scale markers - add colored tick marks at specific values on the scale. Each marker has two parameters:
+    - Position - the value on the scale where the marker should appear, must be within the configured Min/Max range
+    - Color - the color of the tick mark
+
+  Useful for marking operational limits, caution ranges, level notches etc. When Percent format is selected, displayed value is calculated based on the configured minimum and maximum values.
 
 ## Generic Dial (single)
 This action intended to implement plane dial on Stream Dock display. Dial can display value, change value by rotating a knob, call event by pressing a knob/screen.

--- a/com.rvoronov.msfsDock.sdPlugin/propertyInspector/CommonPi/styles.css
+++ b/com.rvoronov.msfsDock.sdPlugin/propertyInspector/CommonPi/styles.css
@@ -92,3 +92,27 @@
     line-height: 1.2;
     padding-top: 2px;
 }
+
+/* ── Markers section ── */
+.sdpi-markers-wrap {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+/* Marker rows reuse .position-row + .sdpi-item-value + <sdpi-button> */
+.sdpi-btn-add {
+    height: 26px;
+    background: #2a2a2a;
+    border: 1px solid #555;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: 12px;
+    cursor: pointer;
+    padding: 0 8px;
+    text-align: center;
+}
+.sdpi-btn-add:hover {
+    border-color: #077fff;
+    color: #fff;
+}

--- a/com.rvoronov.msfsDock.sdPlugin/propertyInspector/CommonPi/styles.css
+++ b/com.rvoronov.msfsDock.sdPlugin/propertyInspector/CommonPi/styles.css
@@ -92,27 +92,3 @@
     line-height: 1.2;
     padding-top: 2px;
 }
-
-/* ── Markers section ── */
-.sdpi-markers-wrap {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-}
-/* Marker rows reuse .position-row + .sdpi-item-value + <sdpi-button> */
-.sdpi-btn-add {
-    height: 26px;
-    background: #2a2a2a;
-    border: 1px solid #555;
-    border-radius: 3px;
-    color: #ccc;
-    font-size: 12px;
-    cursor: pointer;
-    padding: 0 8px;
-    text-align: center;
-}
-.sdpi-btn-add:hover {
-    border-color: #077fff;
-    color: #fff;
-}

--- a/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.html
+++ b/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.html
@@ -29,7 +29,19 @@
         <div class="sdpi-autocomplete">
             <input id="displayVar" class="sdpi-item-value" placeholder="DISPLAY VARIABLE" pattern="[A-Za-z0-9:_. ]*">
         </div>
-        <sdpi-button id="applyDisplayVar" variant="primary">✓</sdpi-button>
+        <sdpi-button id="applyDisplayVar" variant="primary">&#x2713;</sdpi-button>
+    </div>
+
+    <!-- Skin -->
+    <div class="sdpi-item position-row">
+        <div class="sdpi-item-label">Skin</div>
+        <div class="sdpi-radio-group">
+            <input type="radio" id="skinCircular" name="skin" value="circular" checked>
+            <label for="skinCircular" class="sdpi-item-value">Circular</label>
+
+            <input type="radio" id="skinVertical" name="skin" value="vertical">
+            <label for="skinVertical" class="sdpi-item-value">Vertical</label>
+        </div>
     </div>
 
     <!-- Format -->
@@ -83,5 +95,24 @@
         <div class="sdpi-item-label">Background color</div>
         <input type="color" class="sdpi-item-value" id="bgColor" value="#141414">
     </div>
+
+    <!-- Vertical gauge specific options -->
+    <div id="verticalOptions" style="display:none;">
+
+        <div class="sdpi-item position-row">
+            <div class="sdpi-item-label" title="Show zero reference mark on scale">Zero tick</div>
+            <input type="checkbox" id="showZeroTick" checked>
+        </div>
+
+        <div class="sdpi-item position-row">
+            <div class="sdpi-item-label">Scale markers</div>
+            <div style="display:flex; flex-direction:column; gap:2px;">
+                <div id="markersContainer"></div>
+                <button id="addMarkerBtn" style="cursor:pointer;">+ Add marker</button>
+            </div>
+        </div>
+
+    </div>
+
 </body>
 </html>

--- a/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.html
+++ b/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.html
@@ -99,16 +99,11 @@
     <!-- Vertical gauge specific options -->
     <div id="verticalOptions" style="display:none;">
 
-        <div class="sdpi-item position-row">
-            <div class="sdpi-item-label" title="Show zero reference mark on scale">Zero tick</div>
-            <input type="checkbox" id="showZeroTick" checked>
-        </div>
-
-        <div class="sdpi-item position-row">
-            <div class="sdpi-item-label">Scale markers</div>
-            <div style="display:flex; flex-direction:column; gap:2px;">
+        <div class="sdpi-item position-row" style="align-items:flex-start;">
+            <div class="sdpi-item-label" style="padding-top:6px;">Scale markers</div>
+            <div class="sdpi-markers-wrap">
                 <div id="markersContainer"></div>
-                <button id="addMarkerBtn" style="cursor:pointer;">+ Add marker</button>
+                <button id="addMarkerBtn" class="sdpi-btn-add">+ Add marker</button>
             </div>
         </div>
 

--- a/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.html
+++ b/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.html
@@ -101,9 +101,9 @@
 
         <div class="sdpi-item position-row" style="align-items:flex-start;">
             <div class="sdpi-item-label" style="padding-top:6px;">Scale markers</div>
-            <div class="sdpi-markers-wrap">
+            <div style="flex:1; display:flex; flex-direction:column; gap:3px;">
                 <div id="markersContainer"></div>
-                <button id="addMarkerBtn" class="sdpi-btn-add">+ Add marker</button>
+                <sdpi-button id="addMarkerBtn" style="width:fit-content;">+ Add marker</sdpi-button>
             </div>
         </div>
 

--- a/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.js
+++ b/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.js
@@ -5,6 +5,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
     bindRadioGroup("dataFormat", "dataFormat");
     bindRadioGroup("style", "style");
+    bindRadioGroup("skin", "skin");
 
     bindTextField("scaleColor", "scaleColor");
     bindTextField("indicatorColor", "indicatorColor");
@@ -17,4 +18,96 @@ window.addEventListener("DOMContentLoaded", () => {
         autocompleteSource: "vars"
     });
 
+    // --- Skin visibility toggle ---
+    const verticalOptions = document.getElementById("verticalOptions");
+
+    function updateSkinVisibility() {
+        const sel = document.querySelector('input[name="skin"]:checked');
+        const isVertical = sel && sel.value === "vertical";
+        verticalOptions.style.display = isVertical ? "" : "none";
+    }
+
+    document.querySelectorAll('input[name="skin"]').forEach(r => {
+        r.addEventListener("change", updateSkinVisibility);
+    });
+
+    // Update visibility when settings are restored
+    SDPICore.bindings.push({
+        apply() { setTimeout(updateSkinVisibility, 0); }
+    });
+
+    // --- Zero tick checkbox ---
+    const showZeroTick = document.getElementById("showZeroTick");
+
+    showZeroTick.addEventListener("change", () => {
+        commitSettings({ showZeroTick: showZeroTick.checked });
+    });
+
+    SDPICore.bindings.push({
+        apply(settings) {
+            showZeroTick.checked = settings.showZeroTick !== false;
+        }
+    });
+
+    // --- Scale markers ---
+    const markersContainer = document.getElementById("markersContainer");
+    const addMarkerBtn = document.getElementById("addMarkerBtn");
+
+    function addMarkerRow(position, color) {
+        const row = document.createElement("div");
+        row.style.cssText = "display:flex; gap:4px; align-items:center; margin-bottom:2px;";
+
+        const posInput = document.createElement("input");
+        posInput.type = "number";
+        posInput.style.cssText = "width:50px;";
+        posInput.value = position !== undefined ? position : 0;
+        posInput.addEventListener("change", saveMarkers);
+
+        const colorInput = document.createElement("input");
+        colorInput.type = "color";
+        colorInput.style.cssText = "width:40px; height:24px;";
+        colorInput.value = color || "#ffffff";
+        colorInput.addEventListener("change", saveMarkers);
+
+        const removeBtn = document.createElement("button");
+        removeBtn.textContent = "\u2715";
+        removeBtn.style.cursor = "pointer";
+        removeBtn.addEventListener("click", () => { row.remove(); saveMarkers(); });
+
+        row.appendChild(posInput);
+        row.appendChild(colorInput);
+        row.appendChild(removeBtn);
+        markersContainer.appendChild(row);
+    }
+
+    function collectMarkers() {
+        const markers = [];
+        markersContainer.querySelectorAll("div").forEach(row => {
+            const pos = row.querySelector('input[type="number"]');
+            const col = row.querySelector('input[type="color"]');
+            if (pos && col) {
+                markers.push({ position: parseInt(pos.value) || 0, color: col.value });
+            }
+        });
+        return markers;
+    }
+
+    function saveMarkers() {
+        commitSettings({ scaleMarkers: collectMarkers() });
+    }
+
+    addMarkerBtn.addEventListener("click", () => {
+        addMarkerRow(0, "#ffffff");
+        saveMarkers();
+    });
+
+    // Restore markers from settings
+    SDPICore.bindings.push({
+        apply(settings) {
+            markersContainer.innerHTML = "";
+            if (settings.scaleMarkers && Array.isArray(settings.scaleMarkers)) {
+                settings.scaleMarkers.forEach(m => addMarkerRow(m.position, m.color));
+            }
+        }
+    });
 });

--- a/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.js
+++ b/com.rvoronov.msfsDock.sdPlugin/propertyInspector/GenericGauge/index.js
@@ -36,42 +36,28 @@ window.addEventListener("DOMContentLoaded", () => {
         apply() { setTimeout(updateSkinVisibility, 0); }
     });
 
-    // --- Zero tick checkbox ---
-    const showZeroTick = document.getElementById("showZeroTick");
-
-    showZeroTick.addEventListener("change", () => {
-        commitSettings({ showZeroTick: showZeroTick.checked });
-    });
-
-    SDPICore.bindings.push({
-        apply(settings) {
-            showZeroTick.checked = settings.showZeroTick !== false;
-        }
-    });
-
     // --- Scale markers ---
     const markersContainer = document.getElementById("markersContainer");
     const addMarkerBtn = document.getElementById("addMarkerBtn");
 
     function addMarkerRow(position, color) {
         const row = document.createElement("div");
-        row.style.cssText = "display:flex; gap:4px; align-items:center; margin-bottom:2px;";
+        row.classList.add("position-row");
 
         const posInput = document.createElement("input");
         posInput.type = "number";
-        posInput.style.cssText = "width:50px;";
         posInput.value = position !== undefined ? position : 0;
+        posInput.classList.add("sdpi-item-value");
         posInput.addEventListener("change", saveMarkers);
 
         const colorInput = document.createElement("input");
         colorInput.type = "color";
-        colorInput.style.cssText = "width:40px; height:24px;";
         colorInput.value = color || "#ffffff";
+        colorInput.classList.add("sdpi-item-value");
         colorInput.addEventListener("change", saveMarkers);
 
-        const removeBtn = document.createElement("button");
+        const removeBtn = document.createElement("sdpi-button");
         removeBtn.textContent = "\u2715";
-        removeBtn.style.cursor = "pointer";
         removeBtn.addEventListener("click", () => { row.remove(); saveMarkers(); });
 
         row.appendChild(posInput);

--- a/core/GaugeAction.cpp
+++ b/core/GaugeAction.cpp
@@ -18,9 +18,22 @@ void GaugeAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
 
     fill_ = (settings.value("style", "") == "fill") ? true : false;
     dataFormat = (settings.value("dataFormat", "") == "percent") ? DATA_FMT_PERCENT : DATA_FMT_INT;
+    skinType_ = (settings.value("skin", "") == "vertical") ? GAUGE_SKIN_VERTICAL : GAUGE_SKIN_CIRCULAR;
     scaleColor_ = settings.value("scaleColor", "#ffff00");
     indicatorColor_ = settings.value("indicatorColor", "#8b0000");
     bgColor_ = settings.value("bgColor", "#141414");
+
+    // Vertical gauge specific settings
+    showZeroTick_ = settings.value("showZeroTick", true);
+    scaleMarkers_.clear();
+    if (settings.contains("scaleMarkers") && settings["scaleMarkers"].is_array()) {
+        for (const auto& m : settings["scaleMarkers"]) {
+            ScaleMarker sm;
+            sm.position = m.value("position", 0);
+            sm.color = m.value("color", "#ffffff");
+            scaleMarkers_.push_back(sm);
+        }
+    }
 
     std::vector<SimVarDefinition> varsToRegister;
     std::vector<SimVarDefinition> varsToDeregister;
@@ -131,34 +144,63 @@ void GaugeAction::ClearSettings() {
 }
 
 void GaugeAction::UpdateImage() {
-    int headerOffset = 44, headerFontSize = 14, dataOffset = 22, dataFontSize = 20;
     Gdiplus::Color header_color, data_color;
     header_color = COLOR_OFF_WHITE;
     data_color = COLOR_WHITE;
 
     std::string data;
     double value;
-    switch (dataFormat) {
-        case DATA_FMT_INT:
-            data = std::to_string(static_cast<int>(displayVarDef_.value));
-            value = displayVarDef_.value;
-            break;
 
-        case DATA_FMT_PERCENT: {
-            int percent = static_cast<int>(std::round(displayVarDef_.value * 100.0));
-            data = std::to_string(percent) + "%";
-            value = std::round(displayVarDef_.value * 100.0);
-            break;
+    if (skinType_ == GAUGE_SKIN_VERTICAL) {
+        // Vertical gauge: percent is calculated relative to configured min/max range
+        value = displayVarDef_.value;
+        switch (dataFormat) {
+            case DATA_FMT_INT:
+                data = std::to_string(static_cast<int>(value));
+                break;
+            case DATA_FMT_PERCENT: {
+                double range = static_cast<double>(maxVal_) - static_cast<double>(minVal_);
+                int percent = 0;
+                if (range != 0.0) {
+                    percent = static_cast<int>(std::round(((value - minVal_) / range) * 100.0));
+                }
+                data = std::to_string(percent) + "%";
+                break;
+            }
+            default:
+                data = "0";
+                break;
         }
 
-        default:
-            data = "0";
-            value = 0.0;
-            break;
-    }
+        int headerOffset = 57, headerFontSize = 12, dataOffset = 0, dataFontSize = 16;
+        std::string base64Image = DrawVerticalGaugeImage(header_, header_color, value, data, data_color,
+            headerOffset, headerFontSize, dataOffset, dataFontSize, minVal_, maxVal_, fill_,
+            scaleColor_, indicatorColor_, bgColor_, SimManager::Instance().IsConnected(),
+            scaleMarkers_, showZeroTick_);
+        SetImage(base64Image, kESDSDKTarget_HardwareAndSoftware, -1);
+    } else {
+        // Circular gauge (original behavior)
+        switch (dataFormat) {
+            case DATA_FMT_INT:
+                data = std::to_string(static_cast<int>(displayVarDef_.value));
+                value = displayVarDef_.value;
+                break;
+            case DATA_FMT_PERCENT: {
+                int percent = static_cast<int>(std::round(displayVarDef_.value * 100.0));
+                data = std::to_string(percent) + "%";
+                value = std::round(displayVarDef_.value * 100.0);
+                break;
+            }
+            default:
+                data = "0";
+                value = 0.0;
+                break;
+        }
 
-    std::string base64Image = DrawGaugeImage(header_, header_color, value, data, data_color,
-        headerOffset, headerFontSize, dataOffset, dataFontSize, minVal_, maxVal_, fill_,
-        scaleColor_, indicatorColor_, bgColor_, SimManager::Instance().IsConnected());
-    SetImage(base64Image, kESDSDKTarget_HardwareAndSoftware, -1);
+        int headerOffset = 44, headerFontSize = 14, dataOffset = 22, dataFontSize = 20;
+        std::string base64Image = DrawGaugeImage(header_, header_color, value, data, data_color,
+            headerOffset, headerFontSize, dataOffset, dataFontSize, minVal_, maxVal_, fill_,
+            scaleColor_, indicatorColor_, bgColor_, SimManager::Instance().IsConnected());
+        SetImage(base64Image, kESDSDKTarget_HardwareAndSoftware, -1);
+    }
 }

--- a/core/GaugeAction.cpp
+++ b/core/GaugeAction.cpp
@@ -24,7 +24,6 @@ void GaugeAction::UpdateVariablesAndEvents(const nlohmann::json& payload) {
     bgColor_ = settings.value("bgColor", "#141414");
 
     // Vertical gauge specific settings
-    showZeroTick_ = settings.value("showZeroTick", true);
     scaleMarkers_.clear();
     if (settings.contains("scaleMarkers") && settings["scaleMarkers"].is_array()) {
         for (const auto& m : settings["scaleMarkers"]) {
@@ -176,7 +175,7 @@ void GaugeAction::UpdateImage() {
         std::string base64Image = DrawVerticalGaugeImage(header_, header_color, value, data, data_color,
             headerOffset, headerFontSize, dataOffset, dataFontSize, minVal_, maxVal_, fill_,
             scaleColor_, indicatorColor_, bgColor_, SimManager::Instance().IsConnected(),
-            scaleMarkers_, showZeroTick_);
+            scaleMarkers_);
         SetImage(base64Image, kESDSDKTarget_HardwareAndSoftware, -1);
     } else {
         // Circular gauge (original behavior)

--- a/core/GaugeAction.hpp
+++ b/core/GaugeAction.hpp
@@ -16,6 +16,11 @@ enum DataFormat {
     DATA_FMT_PERCENT,
 };
 
+enum GaugeSkin {
+    GAUGE_SKIN_CIRCULAR = 0,
+    GAUGE_SKIN_VERTICAL,
+};
+
 class GaugeAction : public HSDAction, public IUIUpdatable {
 public:
     using HSDAction::HSDAction;
@@ -38,6 +43,7 @@ private:
     // parsed settings
     std::string header_;
     DataFormat dataFormat = DATA_FMT_INT;
+    GaugeSkin skinType_ = GAUGE_SKIN_CIRCULAR;
     std::string displayVar_;
     int maxVal_;
     int minVal_;
@@ -46,6 +52,10 @@ private:
     std::string scaleColor_ = "#ffff00";
     std::string indicatorColor_ = "#8b0000";
     std::string bgColor_ = "#141414";
+
+    // Vertical gauge specific
+    bool showZeroTick_ = true;
+    std::vector<ScaleMarker> scaleMarkers_;
 
     SimVarDefinition displayVarDef_;
 

--- a/core/GaugeAction.hpp
+++ b/core/GaugeAction.hpp
@@ -54,7 +54,6 @@ private:
     std::string bgColor_ = "#141414";
 
     // Vertical gauge specific
-    bool showZeroTick_ = true;
     std::vector<ScaleMarker> scaleMarkers_;
 
     SimVarDefinition displayVarDef_;

--- a/ui/GDIPlusManager.cpp
+++ b/ui/GDIPlusManager.cpp
@@ -679,7 +679,18 @@ std::string DrawVerticalGaugeImage(const std::string& header, Color headerColor,
         t = static_cast<float>((clamped - minVal) / range);
     }
 
-    // Draw fill or pointer indicator
+    // Scale markers (tick marks extending to BOTH sides of the bar) — drawn on top of scale
+    for (const auto& m : scaleMarkers) {
+        if (range == 0.0) continue;
+        float mt = static_cast<float>((m.position - minVal) / range);
+        if (mt < 0.0f) mt = 0.0f;
+        if (mt > 1.0f) mt = 1.0f;
+        float my = barY + barH * (1.0f - mt);
+        Pen mPen(ColorFromHex(m.color), 2.0f);
+        graphics.DrawLine(&mPen, barX - 4.0f, my, barX + barW + 4.0f, my);
+    }
+
+    // Draw fill or pointer indicator — drawn last (on top of scale and markers)
     if (fill) {
         float fillH = barH * t;
         if (fillH < 2.0f && t > 0.0f) fillH = 2.0f;
@@ -698,17 +709,6 @@ std::string DrawVerticalGaugeImage(const std::string& header, Color headerColor,
         };
         SolidBrush triBrush(ColorFromHex(indicatorColor));
         graphics.FillPolygon(&triBrush, triPts, 3);
-    }
-
-    // Scale markers (tick marks extending to BOTH sides of the bar)
-    for (const auto& m : scaleMarkers) {
-        if (range == 0.0) continue;
-        float mt = static_cast<float>((m.position - minVal) / range);
-        if (mt < 0.0f) mt = 0.0f;
-        if (mt > 1.0f) mt = 1.0f;
-        float my = barY + barH * (1.0f - mt);
-        Pen mPen(ColorFromHex(m.color), 2.0f);
-        graphics.DrawLine(&mPen, barX - 4.0f, my, barX + barW + 4.0f, my);
     }
 
     // Header text (bottom, centered full width)

--- a/ui/GDIPlusManager.cpp
+++ b/ui/GDIPlusManager.cpp
@@ -649,7 +649,7 @@ std::string DrawVerticalGaugeImage(const std::string& header, Color headerColor,
                            int minVal, int maxVal, bool fill,
                            std::string scaleColor, std::string indicatorColor, std::string bgColor,
                            bool simConnected,
-                           const std::vector<ScaleMarker>& scaleMarkers, bool showZeroTick) {
+                           const std::vector<ScaleMarker>& scaleMarkers) {
     const int bmpW = 72, bmpH = 72;
     // Scale bar on the RIGHT side, value text on the LEFT -4
     const float barX = 53.0f, barY = 4.0f, barW = 6.0f, barH = 52.0f;
@@ -698,14 +698,6 @@ std::string DrawVerticalGaugeImage(const std::string& header, Color headerColor,
         };
         SolidBrush triBrush(ColorFromHex(indicatorColor));
         graphics.FillPolygon(&triBrush, triPts, 3);
-    }
-
-    // Zero tick mark
-    if (showZeroTick && minVal < 0 && maxVal > 0 && range != 0.0) {
-        float zt = static_cast<float>((0.0 - minVal) / range);
-        float zy = barY + barH * (1.0f - zt);
-        Pen zPen(COLOR_NEAR_BLACK, 2.0f);
-        graphics.DrawLine(&zPen, barX, zy, barX + barW, zy);
     }
 
     // Scale markers (tick marks extending to BOTH sides of the bar)

--- a/ui/GDIPlusManager.cpp
+++ b/ui/GDIPlusManager.cpp
@@ -641,3 +641,110 @@ std::string DrawSwitchImage(const std::vector<std::string>& labels, int currentP
     delete bmp;
     return base64Image;
 }
+
+std::string DrawVerticalGaugeImage(const std::string& header, Color headerColor,
+                           double value, const std::string& data, Color dataColor,
+                           int headerOffset, int headerFontSize,
+                           int dataOffset, int dataFontSize,
+                           int minVal, int maxVal, bool fill,
+                           std::string scaleColor, std::string indicatorColor, std::string bgColor,
+                           bool simConnected,
+                           const std::vector<ScaleMarker>& scaleMarkers, bool showZeroTick) {
+    const int bmpW = 72, bmpH = 72;
+    // Scale bar on the RIGHT side, value text on the LEFT -4
+    const float barX = 53.0f, barY = 4.0f, barW = 6.0f, barH = 52.0f;
+
+    auto* bmp = new Gdiplus::Bitmap(bmpW, bmpH, PixelFormat32bppARGB);
+    if (!bmp || bmp->GetLastStatus() != Ok) {
+        LogError("Bitmap create error!");
+        return {};
+    }
+
+    Graphics graphics(bmp);
+    graphics.Clear(ColorFromHex(bgColor));
+    graphics.SetTextRenderingHint(TextRenderingHintAntiAliasGridFit);
+    graphics.SetSmoothingMode(SmoothingModeAntiAlias);
+
+    // Draw scale bar background
+    SolidBrush scaleBrush(ColorFromHex(scaleColor));
+    graphics.FillRectangle(&scaleBrush, barX, barY, barW, barH);
+
+    // Normalize value to [0, 1] (0 = bottom, 1 = top)
+    double range = static_cast<double>(maxVal) - static_cast<double>(minVal);
+    float t = 0.0f;
+    if (range != 0.0) {
+        double clamped = value;
+        if (clamped < minVal) clamped = minVal;
+        if (clamped > maxVal) clamped = maxVal;
+        t = static_cast<float>((clamped - minVal) / range);
+    }
+
+    // Draw fill or pointer indicator
+    if (fill) {
+        float fillH = barH * t;
+        if (fillH < 2.0f && t > 0.0f) fillH = 2.0f;
+        SolidBrush fillBrush(ColorFromHex(indicatorColor));
+        graphics.FillRectangle(&fillBrush, barX, barY + barH - fillH, barW, fillH);
+    } else {
+        // Pointer indicator: triangle on the RIGHT side of the bar, pointing left
+        float ptrY = barY + barH * (1.0f - t);
+        float triBase = barX + barW + 10.0f;  // right tip of triangle base
+        float triTip = barX + barW + 1.0f;    // left tip (points toward bar)
+        float triHalf = 5.0f;                 // half-height of the triangle
+        Gdiplus::PointF triPts[3] = {
+            { triTip,  ptrY },               // left vertex (tip)
+            { triBase, ptrY - triHalf },     // top-right vertex
+            { triBase, ptrY + triHalf },     // bottom-right vertex
+        };
+        SolidBrush triBrush(ColorFromHex(indicatorColor));
+        graphics.FillPolygon(&triBrush, triPts, 3);
+    }
+
+    // Zero tick mark
+    if (showZeroTick && minVal < 0 && maxVal > 0 && range != 0.0) {
+        float zt = static_cast<float>((0.0 - minVal) / range);
+        float zy = barY + barH * (1.0f - zt);
+        Pen zPen(COLOR_NEAR_BLACK, 2.0f);
+        graphics.DrawLine(&zPen, barX, zy, barX + barW, zy);
+    }
+
+    // Scale markers (tick marks extending to BOTH sides of the bar)
+    for (const auto& m : scaleMarkers) {
+        if (range == 0.0) continue;
+        float mt = static_cast<float>((m.position - minVal) / range);
+        if (mt < 0.0f) mt = 0.0f;
+        if (mt > 1.0f) mt = 1.0f;
+        float my = barY + barH * (1.0f - mt);
+        Pen mPen(ColorFromHex(m.color), 2.0f);
+        graphics.DrawLine(&mPen, barX - 4.0f, my, barX + barW + 4.0f, my);
+    }
+
+    // Header text (bottom, centered full width)
+    DrawHeader(graphics, bmpW, header, headerColor, headerFontSize, headerOffset);
+
+    // Data value text (LEFT of bar, vertically centered on the bar)
+    if (!data.empty()) {
+        float textX = 2.0f;
+        float textW = barX - 4.0f;
+        float textH = barH;  // use bar height region for vertical centering
+
+        SolidBrush brush(dataColor);
+        RectF rect(textX, barY, textW, textH);
+        StringFormat fmt;
+        fmt.SetAlignment(StringAlignmentFar);
+        fmt.SetLineAlignment(StringAlignmentCenter);
+
+        std::wstring wdata = StringToWString(data);
+        FontFamily fontFamily(L"Consolas");
+        Font font(&fontFamily, TO_REAL(dataFontSize), FontStyleRegular, UnitPixel);
+        graphics.DrawString(wdata.c_str(), -1, &font, rect, &fmt, &brush);
+    }
+
+    if (!simConnected) {
+        DrawNotConnectedOutline(graphics, bmpW, bmpH);
+    }
+
+    std::string base64Image = BitmapToBase64(bmp);
+    delete bmp;
+    return base64Image;
+}

--- a/ui/GDIPlusManager.hpp
+++ b/ui/GDIPlusManager.hpp
@@ -5,6 +5,11 @@
 #include <string>
 #include <vector>
 
+struct ScaleMarker {
+    int position = 0;
+    std::string color = "#ffffff";
+};
+
 #define TO_REAL(x) static_cast<Gdiplus::REAL>(x)
 extern const Gdiplus::Color COLOR_WHITE;
 extern const Gdiplus::Color COLOR_OFF_WHITE;
@@ -60,3 +65,14 @@ std::string DrawGaugeImage(const std::string& header = "", Gdiplus::Color header
 
 std::string DrawSwitchImage(const std::vector<std::string>& labels, int currentPosition,
                             const std::string& header = "", bool simConnected = false);
+
+std::string DrawVerticalGaugeImage(const std::string& header = "", Gdiplus::Color headerColor = COLOR_WHITE,
+                           double value = 0, const std::string& data = "", Gdiplus::Color dataColor = COLOR_WHITE,
+                           int headerOffset = 57, int headerFontSize = 12,
+                           int dataOffset = 0, int dataFontSize = 16,
+                           int minVal = 0, int maxVal = 10000, bool fill = false,
+                           std::string scaleColor = "#ffff00", std::string indicatorColor = "#8b0000",
+                           std::string bgColor = "#141414",
+                           bool simConnected = false,
+                           const std::vector<ScaleMarker>& scaleMarkers = {},
+                           bool showZeroTick = true);

--- a/ui/GDIPlusManager.hpp
+++ b/ui/GDIPlusManager.hpp
@@ -74,5 +74,4 @@ std::string DrawVerticalGaugeImage(const std::string& header = "", Gdiplus::Colo
                            std::string scaleColor = "#ffff00", std::string indicatorColor = "#8b0000",
                            std::string bgColor = "#141414",
                            bool simConnected = false,
-                           const std::vector<ScaleMarker>& scaleMarkers = {},
-                           bool showZeroTick = true);
+                           const std::vector<ScaleMarker>& scaleMarkers = {});


### PR DESCRIPTION
### Add Vertical Gauge skin to GaugeAction

Adds a new "Vertical" skin option to the existing Gauge action, allowing users to display sim variables as a vertical bar gauge instead of the default circular gauge.

### Features:

Vertical scale bar positioned on the right side with the numeric value displayed on the left, vertically centered
Triangle pointer indicator on the right side of the scale, pointing toward the bar
Support for fill mode (bar fills from bottom to top) as an alternative to the triangle pointer
User-configurable scale markers that extend on both sides of the bar
Zero tick reference mark for scales with negative ranges
Configurable colors for scale, indicator, and background via the Property Inspector
Skin selection dropdown in the Property Inspector to switch between Circular and Vertical modes
Percentage and integer data format support relative to the configured min/max range